### PR TITLE
chore: enabled fast return logic and bumped relayer version

### DIFF
--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -3,7 +3,7 @@
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.54.0-alpha.5"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.54.0-alpha.5"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.118.0-rc1"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.59.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.62.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "envConfiguration": [
@@ -28,7 +28,8 @@
     {"key": "RELAY_DEBUG_API_ENABLED", "value":  true},
     {"key": "RELAY_HBAR_RATE_LIMIT_BASIC", "value":  "500000000000"},
     {"key": "RELAY_HBAR_RATE_LIMIT_EXTENDED", "value":  "600000000000"},
-    {"key": "RELAY_HBAR_RATE_LIMIT_PRIVILEGED", "value":  "700000000000"}
+    {"key": "RELAY_HBAR_RATE_LIMIT_PRIVILEGED", "value":  "700000000000"},
+    {"key": "RELAY_USE_ASYNC_TX_PROCESSING", "value": true}
 ],
   "nodeConfiguration": {
     "properties": [


### PR DESCRIPTION
**Description**:
Bumped relayer version and enabled fast return logic by enabling USE_ASYNC_TX_PROCESSING env variable in local.json

**Related issue(s)**:

Fixes #892 

**Notes for reviewer**:

**Checklist**

