### PR TITLE
feat: pass java tool options

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ HAVEGED_IMAGE_TAG=0.54.0-alpha.5
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
 PLATFORM_JAVA_HEAP_MAX=2g
-PLATFORM_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:UseSVE=0 -XX:+UseZGC -Xlog:gc*:gc.log"
-GRPC_PLATFORM_JAVA_OPTS="-XX:UseSVE=0"
+PLATFORM_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xlog:gc*:gc.log"
+GRPC_PLATFORM_JAVA_OPTS=""
 #### Bind Mount Settings ####
 NETWORK_NODE_LOGS_ROOT_PATH=./network-logs/node
 APPLICATION_ROOT_PATH=./compose-network/network-node

--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ HAVEGED_IMAGE_TAG=0.54.0-alpha.5
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
 PLATFORM_JAVA_HEAP_MAX=2g
-PLATFORM_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xlog:gc*:gc.log"
-
+PLATFORM_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:UseSVE=0 -XX:+UseZGC -Xlog:gc*:gc.log"
+GRPC_PLATFORM_JAVA_OPTS="-XX:UseSVE=0"
 #### Bind Mount Settings ####
 NETWORK_NODE_LOGS_ROOT_PATH=./network-logs/node
 APPLICATION_ROOT_PATH=./compose-network/network-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       JAVA_HEAP_MIN: "${PLATFORM_JAVA_HEAP_MIN}"
       JAVA_HEAP_MAX: "${PLATFORM_JAVA_HEAP_MAX}"
       JAVA_OPTS: "${PLATFORM_JAVA_OPTS}"
+      JAVA_TOOL_OPTIONS: "${PLATFORM_JAVA_OPTS}"
     healthcheck:
       test:
         [
@@ -229,6 +230,7 @@ services:
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-grpc/
+      JAVA_TOOL_OPTIONS: "${GRPC_PLATFORM_JAVA_OPTS}"
     networks:
       - mirror-node
     ports:
@@ -251,6 +253,7 @@ services:
     environment:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-importer/
+      JAVA_TOOL_OPTIONS: "${GRPC_PLATFORM_JAVA_OPTS}"
     networks:
       - cloud-storage
       - mirror-node
@@ -292,6 +295,7 @@ services:
     environment:
       HEDERA_MIRROR_RESTJAVA_DB_HOST: db
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-rest-java/
+      JAVA_TOOL_OPTIONS: "${GRPC_PLATFORM_JAVA_OPTS}"
     networks:
       - mirror-node
     ports:
@@ -330,6 +334,7 @@ services:
       HEDERA_MIRROR_WEB3_DB_HOST: db
       HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-web3/
+      JAVA_TOOL_OPTIONS: "${GRPC_PLATFORM_JAVA_OPTS}"
     ports:
       - "8545:8545"
     restart: unless-stopped
@@ -355,6 +360,7 @@ services:
       - network-node-bridge
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: "file:/usr/etc/hedera-mirror-monitor/"
+      JAVA_TOOL_OPTIONS: "${GRPC_PLATFORM_JAVA_OPTS}"
     ports:
       - "8082:8082"
     restart: unless-stopped

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -35,6 +35,7 @@ import {
     NETWORK_NODE_CONFIG_DIR_PATH,
     OPTIONAL_PORTS
 } from '../constants';
+import os from 'os';
 
 configDotenv({ path: path.resolve(__dirname, '../../.env') });
 
@@ -201,6 +202,13 @@ export class InitState implements IState{
             this.logger.info(INIT_STATE_RELAY_LIMITS_DISABLED, this.stateName);
         }
         this.logger.info(INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH, this.stateName);
+
+        // workaround for broken Java (21 to 23) on Apple Silicon M3/M4 chipsets under MacOS Sequoia when running inside docker
+        // darwin release history can be found here https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
+        if (os.platform() === "darwin" && os.release().slice(0, 2) === "24") {
+            process.env.PLATFORM_JAVA_OPTS = "-XX:+UnlockExperimentalVMOptions -XX:UseSVE=0 -XX:+UseZGC -Xlog:gc*:gc.log";
+            process.env.GRPC_PLATFORM_JAVA_OPTS = "-XX:UseSVE=0";
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**:

Apparently, there's a bug when running this JRE version with hosts running M4 Sequoia Mac OS. See [here](https://x.com/starbuxman/status/1869887463923298748), [here](https://github.com/corretto/corretto-23/pull/10) and [here](https://medium.com/@luketn/java-on-docker-sigill-exception-on-mac-os-sequoia-15-2-9311e4775442)

**Solution**:

Set default value for `"-XX:UseSVE=0"`