### PR TITLE
ci: remove unrecognized brew update option in Smoke Tests

### DIFF
--- a/.github/workflows/flow-pull-request-smoke-tests-on-macos.yaml
+++ b/.github/workflows/flow-pull-request-smoke-tests-on-macos.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Update Homebrew
         run: |
-          brew update --preinstall
+          brew update
 
       - name: Install Lima
         run: |


### PR DESCRIPTION
The `--preinstall` option for brew update doesn't exist and [passing non-existent options to the brew update command in newer homebrew versions causes an error with exit code 1.](https://github.com/Homebrew/brew/pull/19083)

This can be observed in [failing Smoke Tests workflow runs](https://github.com/hiero-ledger/hiero-local-node/actions/runs/13367865032/job/37329606656) from the last month or so.