### PR TITLE
feat: use a locally built images in the local node

### DIFF
--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -209,8 +209,10 @@ export class DockerService implements IService{
     public checkDockerImages() {
         const dockerComposeYml = yaml.load(shell.exec("docker compose config", { silent: true }).stdout) as any;
         const dockerComposeImages = Object.values(dockerComposeYml.services).map((s: any) => {
-            const parsed = s.image.split(":");
-            return `${parsed[0]}:${parsed[1] ?? "latest"}`;
+            if (s.image) {
+                const parsed = s.image.split(":");
+                return `${parsed[0]}:${parsed[1] ?? "latest"}`;
+            }
         });
         const dockerComposeImagesUnique = [...new Set(dockerComposeImages.sort())];
 


### PR DESCRIPTION
**Description**:

The local node does not seem to start with a custom web3 image for the mirror web3 module.

**Related issue(s)**:

Fixes: #945 