### PR TITLE
feat: improve devex in cli

### DIFF
--- a/src/controller/StateController.ts
+++ b/src/controller/StateController.ts
@@ -57,7 +57,7 @@ export class StateController implements IOBserver{
         this.currStateNum = 0;
         this.maxStateNum = 0;
         this.logger.trace(`${CHECK_SUCCESS} State Controller Initialized!`, this.controllerName);
-        this.logger.info(`${CHECK_SUCCESS} Starting ${stateName} procedure!`, this.controllerName);
+        this.logger.trace(`${CHECK_SUCCESS} Initiating ${stateName} procedure!`, this.controllerName);
     }
 
     /**

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -36,6 +36,7 @@ import {
     OPTIONAL_PORTS
 } from '../constants';
 import os from 'os';
+import packageJson from '../../package.json';
 
 configDotenv({ path: path.resolve(__dirname, '../../.env') });
 
@@ -95,6 +96,7 @@ export class InitState implements IState{
      * @returns {Promise<void>} A promise that resolves when the state has started.
      */
     public async onStart(): Promise<void> {
+        this.printLogoAndVersion();
         this.logger.trace(INIT_STATE_STARTING_MESSAGE, this.stateName);
         const configurationData = ConfigurationData.getInstance();
 
@@ -160,7 +162,7 @@ export class InitState implements IState{
      * @returns {void}
     */
     private prepareWorkDirectory() {
-        this.logger.info(`${CHECK_SUCCESS} Local Node Working directory set to ${this.cliOptions.workDir}.`, this.stateName);
+        this.logger.trace(`${CHECK_SUCCESS} Local Node Working directory set to ${this.cliOptions.workDir}.`, this.stateName);
         FileSystemUtils.createEphemeralDirectories(this.cliOptions.workDir);
         const configDirSource = join(__dirname, `../../${NETWORK_NODE_CONFIG_DIR_PATH}`);
         const configPathMirrorNodeSource = join(__dirname, `../../${APPLICATION_YML_RELATIVE_PATH}`);
@@ -201,7 +203,7 @@ export class InitState implements IState{
             process.env.RELAY_RATE_LIMIT_DISABLED = `${relayLimitsDisabled}`;
             this.logger.info(INIT_STATE_RELAY_LIMITS_DISABLED, this.stateName);
         }
-        this.logger.info(INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH, this.stateName);
+        this.logger.trace(INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH, this.stateName);
 
         // workaround for broken Java (21 to 23) on Apple Silicon M3/M4 chipsets under MacOS Sequoia when running inside docker
         // darwin release history can be found here https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
@@ -285,7 +287,7 @@ export class InitState implements IState{
 
             writeFileSync(propertiesFilePath, newProperties, { flag: 'w' });
 
-            this.logger.info(INIT_STATE_BOOTSTRAPPED_PROP_SET, this.stateName);
+            this.logger.trace(INIT_STATE_BOOTSTRAPPED_PROP_SET, this.stateName);
         }
     }
 
@@ -317,6 +319,71 @@ export class InitState implements IState{
         }
 
         writeFileSync(propertiesFilePath, yaml.dump(application, { lineWidth: 256 }));
-        this.logger.info(INIT_STATE_MIRROR_PROP_SET, this.stateName);
+        this.logger.trace(INIT_STATE_MIRROR_PROP_SET, this.stateName);
+    }
+
+    /**
+     * Prints the Hiero Local-Node logo and version information.
+     * @private
+     */
+    private printLogoAndVersion(): void {
+        const logo = `
+                         ██╗  ██╗██╗███████╗██████╗  ██████╗ 
+                         ██║  ██║██║██╔════╝██╔══██╗██╔═══██╗
+                         ███████║██║█████╗  ██████╔╝██║   ██║
+                         ██╔══██║██║██╔══╝  ██╔══██╗██║   ██║
+                         ██║  ██║██║███████╗██║  ██║╚██████╔╝
+                         ╚═╝  ╚═╝╚═╝╚══════╝╚═╝  ╚═╝ ╚═════╝
+                                          
+    ██╗      ██████╗  ██████╗ █████╗ ██╗        ███╗   ██╗ ██████╗ ██████╗ ███████╗
+    ██║     ██╔═══██╗██╔════╝██╔══██╗██║        ████╗  ██║██╔═══██╗██╔══██╗██╔════╝
+    ██║     ██║   ██║██║     ███████║██║        ██╔██╗ ██║██║   ██║██║  ██║█████╗  
+    ██║     ██║   ██║██║     ██╔══██║██║        ██║╚██╗██║██║   ██║██║  ██║██╔══╝  
+    ███████╗╚██████╔╝╚██████╗██║  ██║███████╗   ██║ ╚████║╚██████╔╝██████╔╝███████╗
+    ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝╚══════╝   ╚═╝  ╚═══╝ ╚═════╝ ╚═════╝ ╚══════╝
+    `;
+
+        const versionInfo = `    Local-Node Version: ${packageJson.version}`;
+        const divider = `    ─────────────────────────────────────────────`;
+        const nodesVersionDivider = `
+${divider}
+    Hiero Nodes Version
+${divider}`;
+
+        const configurationData = ConfigurationData.getInstance();
+        const nodeVersions = configurationData.imageTagConfiguration
+            .reduce((acc, variable) => {
+                const { tag, node } = this.extractImageTag(variable);
+                let nodeName = '';
+                switch (node) {
+                    case "NETWORK_NODE_IMAGE_TAG":
+                        nodeName = "Consensus Node";
+                        break;
+                    case "MIRROR_IMAGE_TAG":
+                        nodeName = "Mirror Node";
+                        break;
+                    case "RELAY_IMAGE_TAG":
+                        nodeName = "Relay";
+                        break;
+                    case "BLOCK_NODE_IMAGE_TAG":
+                        nodeName = "Block Node";
+                        break;
+                    default:
+                        return acc;
+                }
+                // Only add if we haven't seen this node type before
+                if (!acc.some(item => item.startsWith(nodeName))) {
+                    acc.push(`    ${nodeName} Version: ${tag}`);
+                }
+                return acc;
+            }, [] as string[])
+            .join('\n');
+        
+        console.log(logo);
+        console.log(versionInfo);   
+        console.log(nodesVersionDivider);
+        console.log(nodeVersions);
+        console.log(divider);
+        console.log();
     }
 }

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -369,6 +369,9 @@ ${divider}`;
                     case "BLOCK_NODE_IMAGE_TAG":
                         nodeName = "Block Node";
                         break;
+                    case "MIRROR_NODE_EXPLORER_IMAGE_TAG":
+                        nodeName = "Mirror Node Explorer";
+                        break;
                     default:
                         return acc;
                 }

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -41,6 +41,11 @@ import { VerboseLevel } from '../types/VerboseLevel';
 
 configDotenv({ path: path.resolve(__dirname, '../../.env') });
 
+interface PackageMeta {
+    version: string;
+}
+const LOCAL_NODE_VERSION: string = (packageJson as PackageMeta).version;
+
 /**
  * Represents the initialization state of the application.
  * This state is responsible for setting up the necessary environment variables,
@@ -344,7 +349,7 @@ export class InitState implements IState{
     ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝╚══════╝   ╚═╝  ╚═══╝ ╚═════╝ ╚═════╝ ╚══════╝
     `;
 
-        const versionInfo = `    Local-Node Version: ${packageJson.version}`;
+        const versionInfo = `    Local-Node Version: ${LOCAL_NODE_VERSION}`;
         const divider = `    ─────────────────────────────────────────────`;
         const nodesVersionDivider = `
 ${divider}
@@ -380,7 +385,7 @@ ${divider}`;
                     acc.push(`    ${nodeName} Version: ${tag}`);
                 }
                 return acc;
-            }, [] as string[])
+            }, [] as Array<string>)
             .join('\n');
 
         const configStatusDivider = `

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -37,6 +37,7 @@ import {
 } from '../constants';
 import os from 'os';
 import packageJson from '../../package.json';
+import { VerboseLevel } from '../types/VerboseLevel';
 
 configDotenv({ path: path.resolve(__dirname, '../../.env') });
 
@@ -378,11 +379,26 @@ ${divider}`;
                 return acc;
             }, [] as string[])
             .join('\n');
+
+        const configStatusDivider = `
+${divider}
+    Configuration Status
+${divider}`;
+
+        const configStatus = [
+            `    Node Configuration: ${this.cliOptions.multiNode ? 'Multi' : 'Single'} Node`,
+            `    Block Node: ${this.cliOptions.blockNode ? 'Enabled' : 'Disabled'}`,
+            `    Host: ${this.cliOptions.host}`,
+            `    Verbose Level: ${VerboseLevel[this.cliOptions.verbose]}`
+        ].join('\n');
         
         console.log(logo);
         console.log(versionInfo);   
         console.log(nodesVersionDivider);
         console.log(nodeVersions);
+        console.log(divider);
+        console.log(configStatusDivider);
+        console.log(configStatus);
         console.log(divider);
         console.log();
     }

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -342,7 +342,7 @@ describe('InitState tests', () => {
             onStartStub = testSandbox.stub(initState, 'onStart')
             .callsFake(() => (initState  as any).configureMirrorNodeProperties())
             await initState.onStart();
-            testSandbox.assert.calledOnceWithExactly(loggerService.trace, INIT_STATE_MIRROR_PROP_SET, InitState.name);
+            testSandbox.assert.calledTwice(loggerService.trace);
             testSandbox.assert.called(fsReadFileSync);
             testSandbox.assert.called(fsWriteFileSync);
             testSandbox.assert.called(ymlLoad);
@@ -402,7 +402,7 @@ describe('InitState tests', () => {
 
             it('should set the persist properties for transactionBytes and transactionRecordBytes to true', async () => {
                 await initState.onStart();
-                testSandbox.assert.calledOnceWithExactly(loggerService.trace, INIT_STATE_MIRROR_PROP_SET, InitState.name);
+                testSandbox.assert.calledTwice(loggerService.trace);
                 testSandbox.assert.called(fsReadFileSync);
                 testSandbox.assert.called(fsWriteFileSync);
                 testSandbox.assert.called(ymlLoad);

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -134,7 +134,7 @@ describe('InitState tests', () => {
 
         // loggin messages
         testSandbox.assert.calledWithExactly(loggerService.trace, INIT_STATE_STARTING_MESSAGE, InitState.name);
-        testSandbox.assert.calledOnce(configurationData)
+        testSandbox.assert.calledTwice(configurationData)
         testSandbox.assert.calledWithExactly(loggerService.info, INIT_STATE_START_DOCKER_CHECK, InitState.name);
         testSandbox.assert.calledOnce(dockerService.isCorrectDockerComposeVersion);
         testSandbox.assert.calledOnce(dockerService.checkDocker);
@@ -154,7 +154,7 @@ describe('InitState tests', () => {
 
         // loggin messages
         testSandbox.assert.calledOnceWithExactly(loggerService.trace, INIT_STATE_STARTING_MESSAGE, InitState.name);
-        testSandbox.assert.calledOnce(configurationData)
+        testSandbox.assert.calledTwice(configurationData)
         testSandbox.assert.calledOnceWithExactly(loggerService.info, INIT_STATE_START_DOCKER_CHECK, InitState.name);
         testSandbox.assert.calledOnce(dockerService.isCorrectDockerComposeVersion);
         testSandbox.assert.calledOnce(dockerService.checkDocker);
@@ -238,7 +238,7 @@ describe('InitState tests', () => {
             onStartStub = testSandbox.stub(initState, 'onStart')
                 .callsFake(() => (initState  as any).prepareWorkDirectory())
             await initState.onStart();
-            testSandbox.assert.calledWithExactly(loggerService.info, `${CHECK_SUCCESS} Local Node Working directory set to testDir.`, InitState.name);
+            testSandbox.assert.calledWithExactly(loggerService.trace, `${CHECK_SUCCESS} Local Node Working directory set to testDir.`, InitState.name);
             testSandbox.assert.calledOnceWithExactly(createEphemeralDirectoriesStub, "testDir");
             testSandbox.assert.calledOnceWithExactly(copyPathsStub, configFiles);
 
@@ -259,7 +259,7 @@ describe('InitState tests', () => {
             testSandbox.assert.match(process.env.TEST_VAR_2, 'test');
             testSandbox.assert.called(loggerService.trace);
             testSandbox.assert.called(extractImageTagStub);
-            testSandbox.assert.calledWithExactly(loggerService.info, INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH, InitState.name);
+            testSandbox.assert.calledWithExactly(loggerService.trace, INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH, InitState.name);
             testSandbox.assert.calledWithExactly(loggerService.info, INIT_STATE_RELAY_LIMITS_DISABLED, InitState.name);
 
             configureEnvVariablesStub = testSandbox.stub(initState as any, 'configureEnvVariables')
@@ -319,7 +319,7 @@ describe('InitState tests', () => {
                     TEST_CONFIGURATION.nodeConfiguration.properties
                 ))
             await initState.onStart();
-            testSandbox.assert.calledWithExactly(loggerService.info, INIT_STATE_BOOTSTRAPPED_PROP_SET, InitState.name);
+            testSandbox.assert.calledWithExactly(loggerService.trace, INIT_STATE_BOOTSTRAPPED_PROP_SET, InitState.name);
             testSandbox.assert.called(fsWriteFileSync);
 
             configureNodePropertiesStub = testSandbox.stub(initState as any, 'configureNodeProperties')
@@ -342,7 +342,7 @@ describe('InitState tests', () => {
             onStartStub = testSandbox.stub(initState, 'onStart')
             .callsFake(() => (initState  as any).configureMirrorNodeProperties())
             await initState.onStart();
-            testSandbox.assert.calledOnceWithExactly(loggerService.info, INIT_STATE_MIRROR_PROP_SET, InitState.name);
+            testSandbox.assert.calledOnceWithExactly(loggerService.trace, INIT_STATE_MIRROR_PROP_SET, InitState.name);
             testSandbox.assert.called(fsReadFileSync);
             testSandbox.assert.called(fsWriteFileSync);
             testSandbox.assert.called(ymlLoad);
@@ -402,7 +402,7 @@ describe('InitState tests', () => {
 
             it('should set the persist properties for transactionBytes and transactionRecordBytes to true', async () => {
                 await initState.onStart();
-                testSandbox.assert.calledOnceWithExactly(loggerService.info, INIT_STATE_MIRROR_PROP_SET, InitState.name);
+                testSandbox.assert.calledOnceWithExactly(loggerService.trace, INIT_STATE_MIRROR_PROP_SET, InitState.name);
                 testSandbox.assert.called(fsReadFileSync);
                 testSandbox.assert.called(fsWriteFileSync);
                 testSandbox.assert.called(ymlLoad);


### PR DESCRIPTION
**Description**:

Changes:
- Added a new ASCII art logo display for Hiero Local-Node
- Implemented a structured version and configuration information display
- Reduced log verbosity by changing several `info` logs to `trace` level in certain places

New Features:
1. **Logo Display**
   - Added ASCII art logo for "Hiero" and "Local-Node"
   - Centered and properly formatted display

2. **Version Information**
   - Added Local-Node version from package.json
   - Added Hiero Nodes version section showing:
     - Consensus Node Version
     - Mirror Node Version
     - Relay Version
     - Block Node Version

3. **Configuration Status**
   - Added a new section showing:
     - Node Configuration (Single/Multi)
     - Block Node status
     - Host address
     - Verbose Level (using VerboseLevel enum)

Technical Changes:
- Added new `printLogoAndVersion` method in `InitState` class

Fixes #1083 

**Notes for reviewer**:
New CLI upon startup:
![image](https://github.com/user-attachments/assets/2d484e82-3293-4b00-ae7b-817fd66957d1)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
