### PR TITLE
chore: revert `block-node` enabled by default

### DIFF
--- a/src/services/CLIService.ts
+++ b/src/services/CLIService.ts
@@ -280,7 +280,7 @@ export class CLIService implements IService{
             type: 'boolean',
             describe: 'Enable or disable block-node',
             demandOption: false,
-            default: true
+            default: false
         });
     }
 


### PR DESCRIPTION
**Description**:
This PR flips the enable block node feature flag to false, until the node matures enough to be enabled.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
